### PR TITLE
chore: use globalDescribe to get sobject types quicker for uow

### DIFF
--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIProvider.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIProvider.cls
@@ -79,7 +79,7 @@ public class ApplicationSObjectUnitOfWorkDIProvider
         {
             // then query default ApplicationFactory_UnitOfWorkBinding__mdt records
             this.sObjTypesParam = new List<Schema.SObjectType>();
-            Schema.DescribeSobjectResult[] sobjDescribe = null;
+            Map<String, SObjectType> sObjectTypeByName = Schema.getGlobalDescribe();
 
             String bindingSObjectAPIName = null;
 
@@ -92,17 +92,16 @@ public class ApplicationSObjectUnitOfWorkDIProvider
             {
                 bindingSObjectAPIName = String.isNotBlank(bindingConfig.BindingSObject__c) ? bindingConfig.BindingSObject__r.QualifiedApiName : bindingConfig.BindingSObjectAlternate__c;
 
-                if (String.isNotBlank(bindingSObjectAPIName)) 
+                if (String.isNotBlank(bindingSObjectAPIName))
                 {
-                    sobjDescribe = Schema.describeSObjects(new String[] { bindingSObjectAPIName.toLowerCase().trim() });
-
-                    if(sobjDescribe.size() != 1) 
+                    String sObjectApiName = bindingSObjectAPIName.toLowerCase().trim();
+                    if(!sObjectTypeByName.containsKey(sObjectApiName))
                     {
-                        throw new di_Injector.InjectorException('Failed to find SObject ' + bindingSObjectAPIName 
-                                                                     + ' referened by binding ' + bindingConfig.DeveloperName 
+                        throw new di_Injector.InjectorException('Failed to find SObject ' + bindingSObjectAPIName
+                                                                     + ' referened by binding ' + bindingConfig.DeveloperName
                                                                      + ' for ApplicationSObjectUnitOfWorkDIModule di_Injectory module.');
                     }
-                    this.sObjTypesParam.add( sobjDescribe[0].getSObjectType() );
+                    this.sObjTypesParam.add( sObjectTypeByName.get(sObjectApiName) );
                 }
             }
         }


### PR DESCRIPTION
removed the one by one getDescribe for each sObjectType in the binding for the uow and instead use one on global describe to quickly retrieve all available sobjects by name.

See issue : https://github.com/ImJohnMDaniel/at4dx/issues/29

Code Snippet : 
```        
System.debug('Start : ' + Limits.getCpuTime());
IApplicationSObjectUnitOfWork uow = Application.UnitOfWork.newInstance();
System.debug('Stop : ' + Limits.getCpuTime());
```

Before : 
2000 - 2500ms to execute above line of code

Now : 
300 - 450ms to execute above line of code